### PR TITLE
[HB-5223] Account for unsupported ad formats

### DIFF
--- a/AmazonPublisherServicesAdapter/src/main/java/com/chartboost/mediation/amazonpublisherservicesadapter/AmazonPublisherServicesAdapter.kt
+++ b/AmazonPublisherServicesAdapter/src/main/java/com/chartboost/mediation/amazonpublisherservicesadapter/AmazonPublisherServicesAdapter.kt
@@ -469,7 +469,7 @@ class AmazonPublisherServicesAdapter : PartnerAdapter {
                 PartnerLogController.log(LOAD_FAILED)
                 Result.failure(ChartboostMediationAdException(ChartboostMediationError.CM_LOAD_FAILURE_UNSUPPORTED_AD_FORMAT))
             }
-            AdFormat.REWARDED_INTERSTITIAL -> {
+            else -> {
                 PartnerLogController.log(LOAD_FAILED)
                 Result.failure(ChartboostMediationAdException(ChartboostMediationError.CM_LOAD_FAILURE_UNSUPPORTED_AD_FORMAT))
             }
@@ -503,7 +503,7 @@ class AmazonPublisherServicesAdapter : PartnerAdapter {
                 PartnerLogController.log(SHOW_FAILED)
                 Result.failure(ChartboostMediationAdException(ChartboostMediationError.CM_LOAD_FAILURE_UNSUPPORTED_AD_FORMAT))
             }
-            AdFormat.REWARDED_INTERSTITIAL -> {
+            else -> {
                 PartnerLogController.log(LOAD_FAILED)
                 Result.failure(ChartboostMediationAdException(ChartboostMediationError.CM_SHOW_FAILURE_UNSUPPORTED_AD_FORMAT))
             }

--- a/AmazonPublisherServicesAdapter/src/main/java/com/chartboost/mediation/amazonpublisherservicesadapter/AmazonPublisherServicesAdapter.kt
+++ b/AmazonPublisherServicesAdapter/src/main/java/com/chartboost/mediation/amazonpublisherservicesadapter/AmazonPublisherServicesAdapter.kt
@@ -469,6 +469,10 @@ class AmazonPublisherServicesAdapter : PartnerAdapter {
                 PartnerLogController.log(LOAD_FAILED)
                 Result.failure(ChartboostMediationAdException(ChartboostMediationError.CM_LOAD_FAILURE_UNSUPPORTED_AD_FORMAT))
             }
+            AdFormat.REWARDED_INTERSTITIAL -> {
+                PartnerLogController.log(LOAD_FAILED)
+                Result.failure(ChartboostMediationAdException(ChartboostMediationError.CM_LOAD_FAILURE_UNSUPPORTED_AD_FORMAT))
+            }
         }
     }
 
@@ -497,6 +501,10 @@ class AmazonPublisherServicesAdapter : PartnerAdapter {
             AdFormat.INTERSTITIAL -> showInterstitialAd(partnerAd)
             AdFormat.REWARDED -> {
                 PartnerLogController.log(SHOW_FAILED)
+                Result.failure(ChartboostMediationAdException(ChartboostMediationError.CM_LOAD_FAILURE_UNSUPPORTED_AD_FORMAT))
+            }
+            AdFormat.REWARDED_INTERSTITIAL -> {
+                PartnerLogController.log(LOAD_FAILED)
                 Result.failure(ChartboostMediationAdException(ChartboostMediationError.CM_LOAD_FAILURE_UNSUPPORTED_AD_FORMAT))
             }
         }

--- a/AmazonPublisherServicesAdapter/src/main/java/com/chartboost/mediation/amazonpublisherservicesadapter/AmazonPublisherServicesAdapter.kt
+++ b/AmazonPublisherServicesAdapter/src/main/java/com/chartboost/mediation/amazonpublisherservicesadapter/AmazonPublisherServicesAdapter.kt
@@ -505,7 +505,7 @@ class AmazonPublisherServicesAdapter : PartnerAdapter {
             }
             AdFormat.REWARDED_INTERSTITIAL -> {
                 PartnerLogController.log(LOAD_FAILED)
-                Result.failure(ChartboostMediationAdException(ChartboostMediationError.CM_LOAD_FAILURE_UNSUPPORTED_AD_FORMAT))
+                Result.failure(ChartboostMediationAdException(ChartboostMediationError.CM_SHOW_FAILURE_UNSUPPORTED_AD_FORMAT))
             }
         }
     }


### PR DESCRIPTION
Note: While PR is code and feature complete, do not merge until feature is tested end-to-end. We also need the new Chartboost Mediation SDK to be in production first before adapters can be released.