### PR TITLE
[HB-6578] Amazon Publisher Services SDK 9.8.6

### DIFF
--- a/AmazonPublisherServicesAdapter/build.gradle.kts
+++ b/AmazonPublisherServicesAdapter/build.gradle.kts
@@ -35,7 +35,7 @@ android {
         minSdk = 21
         targetSdk = 33
         // If you touch the following line, don't forget to update scripts/get_rc_version.zsh
-        android.defaultConfig.versionName = System.getenv("VERSION_OVERRIDE") ?: "4.9.8.5.0"
+        android.defaultConfig.versionName = System.getenv("VERSION_OVERRIDE") ?: "4.9.8.6.0"
         buildConfigField("String", "CHARTBOOST_MEDIATION_APS_ADAPTER_VERSION", "\"${android.defaultConfig.versionName}\"")
 
         consumerProguardFiles("proguard-rules.pro")

--- a/AmazonPublisherServicesAdapter/build.gradle.kts
+++ b/AmazonPublisherServicesAdapter/build.gradle.kts
@@ -72,7 +72,7 @@ dependencies {
     "remoteImplementation"("com.chartboost:chartboost-mediation-sdk:4.0.0")
 
     //Partner SDK
-    implementation("com.amazon.android:aps-sdk:9.8.5")
+    implementation("com.amazon.android:aps-sdk:9.8.6")
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.6.4")
     implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.4.1")
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 Note the first digit of every adapter version corresponds to the major version of the Chartboost Mediation SDK compatible with that adapter. 
 Adapters are compatible with any Chartboost Mediation SDK version within that major version.
 
+### 4.9.8.6.0
+- This version of the adapter has been certified with Amazon Publisher Services SDK 9.8.6.
+
 ### 4.9.8.5.0
 - This version of the adapter has been certified with Amazon Publisher Services SDK 9.8.5.
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ The Chartboost Mediation Amazon Publisher Services adapter mediates Amazon Publi
 
 In your `build.gradle`, add the following entry:
 ```
-    implementation "com.chartboost:chartboost-mediation-adapter-amazon-publisher-services:4.9.8.5.0"
+    implementation "com.chartboost:chartboost-mediation-adapter-amazon-publisher-services:4.9.8.6.0"
 ```
 
 ## Contributions


### PR DESCRIPTION
- Updated Amazon Publisher Services SDK version to 9.8.6
- Updated Changelog, README, build script to 4.9.8.6.0