### PR TITLE
Update CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@ All official releases can be found on this repository's [releases page](https://
 
 ## Mediation 4
 
+### 4.9.10.3.0
+- This version of the adapter has been certified with Amazon Publisher Services SDK 9.10.3.
+
 ### 4.9.10.2.0
 - This version of the adapter has been certified with Amazon Publisher Services SDK 9.10.2.
 


### PR DESCRIPTION
Adds Amazon Publisher Services adapter version `4.9.10.3.0` to CHANGELOG for PR https://github.com/ChartBoost/chartboost-mediation-android-adapter-amazon-publisher-services/pull/86