### PR TITLE
fix: update APS adapter minSdk to 23

### DIFF
--- a/AmazonPublisherServicesAdapter/build.gradle.kts
+++ b/AmazonPublisherServicesAdapter/build.gradle.kts
@@ -39,7 +39,7 @@ android {
     compileSdk = 34
 
     defaultConfig {
-        minSdk = 21
+        minSdk = 23
         targetSdk = 34
         // If you touch the following line, don't forget to update scripts/get_rc_version.zsh
         android.defaultConfig.versionName = System.getenv("VERSION_OVERRIDE") ?: "5.11.1.2.0"


### PR DESCRIPTION
The APS SDK 11.1.1+ declares minSdkVersion 23 in its AAR manifest. While regular library assembly tolerates this mismatch (library manifest merging is lenient), building androidTest variants produces a test APK which enforces strict minSdk compatibility, causing manifest merger failures:

  uses-sdk:minSdkVersion 21 cannot be smaller than version 23
  declared in library [com.amazon.android:aps-sdk]